### PR TITLE
fix: resolve iconv error by switching to mb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "ext-iconv": "*"
+        "ext-iconv": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "codacy/coverage": "^1.4.3",

--- a/src/Parsing/ParserState.php
+++ b/src/Parsing/ParserState.php
@@ -221,7 +221,7 @@ class ParserState
                 $sUtf32 .= \chr($iUnicode & 0xff);
                 $iUnicode = $iUnicode >> 8;
             }
-            return \iconv('utf-32le', $this->sCharset, $sUtf32);
+            return mb_convert_encoding($sUtf32, $this->sCharset, 'UTF-32LE');
         }
 
         if (!$bIsForIdentifier) {


### PR DESCRIPTION
The `iconv` function is causing some errors and appears to be slower. We can use `mb_convert_encoding` instead.